### PR TITLE
Add placeholders for new issues.

### DIFF
--- a/plugin/nvim_diary_template.vim
+++ b/plugin/nvim_diary_template.vim
@@ -32,7 +32,7 @@ function! DiaryFoldText()
 
     let l:labels = filter(map(split(l:start_line), 'matchstr(v:val, s:label)'), {idx, val -> val != ''})
 
-    let l:issue_number = matchstr(l:start_line, '\d')
+    let l:issue_number = matchstr(l:start_line, '\d\{1,}')
     let l:issue_status = matchstr(l:start_line, '\[X\]')
 
     let l:completed_status = '[ ]'
@@ -60,7 +60,7 @@ function! DiaryFoldText()
     let l:padding = '        '
     let l:comment_brief = substitute(l:start_of_comment, l:padding, '', "")
 
-    let l:comment_number = matchstr(l:start_line, '\d')
+    let l:comment_number = matchstr(l:start_line, '\d\{1,}')
     let l:comment_date_time = matchstr(l:start_line, s:date_time_regex)
 
     return '### Comment {' . l:comment_number . "} - " . l:comment_date_time . ": " . l:comment_brief . "."

--- a/plugin/nvim_diary_template.vim
+++ b/plugin/nvim_diary_template.vim
@@ -14,8 +14,8 @@ augroup nvim_diary_template_keybinds
     autocmd FileType vimwiki setlocal foldexpr=GetDiaryFold(v:lnum)
 augroup END
 
-let s:issue_start = '^## \[[ X]\] Issue {\d}:'
-let s:comment_start = '^### Comment {\d} - '
+let s:issue_start = '^## \[[ X]\] Issue {\d\{1,}}:'
+let s:comment_start = '^### Comment {\d\{1,}} - '
 let s:date_time_regex = '\d\{4}-\d\{2}-\d\{2} \d\{2}:\d\{2}'
 let s:label = '+label:\a\{1,}'
 

--- a/rplugin/python3/nvim_diary_template/helpers/issue_helpers.py
+++ b/rplugin/python3/nvim_diary_template/helpers/issue_helpers.py
@@ -33,6 +33,7 @@ def convert_issues(github_service):
         formatted_issues.append({
             'number': issue['number'],
             'title': issue['title'],
+            'complete': issue['complete'],
             'labels': issue['labels'],
             'all_comments': comments,
         })

--- a/rplugin/python3/nvim_diary_template/helpers/issue_helpers.py
+++ b/rplugin/python3/nvim_diary_template/helpers/issue_helpers.py
@@ -106,7 +106,8 @@ def insert_new_issue(nvim):
 
     issue_start = f"{HEADING_2} {EMPTY_TODO} Issue {{00}}: +new"
     title_line = f"{HEADING_3} Title: "
-    comment_line = f"{HEADING_3} Comment {{0}}:"
+    comment_line = f"{HEADING_3} Comment {{0}} - 0000-00-00 00:00: +new"
+
     new_comment = [
         '',
         issue_start,
@@ -172,7 +173,7 @@ def insert_new_comment(nvim):
 
     # Add a new issue comment line, and set the line, before moving the cursor
     # there.
-    header_line = f"{HEADING_3} Comment {{{comment_number + 1}}}: +new"
+    header_line = f"{HEADING_3} Comment {{{comment_number + 1}}} - 0000-00-00 00:00: +new"
     new_comment = ['', header_line, '']
 
     set_line_content(nvim, new_comment, line_index=new_line_number)

--- a/rplugin/python3/nvim_diary_template/helpers/issue_helpers.py
+++ b/rplugin/python3/nvim_diary_template/helpers/issue_helpers.py
@@ -99,25 +99,12 @@ def insert_new_issue(nvim):
 
     # Grab the indexes needed to find the issue we are in.
     current_buffer = get_buffer_contents(nvim)
-    issues_header_index = get_section_line(current_buffer, ISSUE_HEADING)
     schedule_header_index = get_section_line(
         current_buffer, SCHEDULE_HEADING) - 1
 
-    relevant_buffer = current_buffer[issues_header_index:schedule_header_index]
-
-    # Search the buffer backwards and find the start of the last issue, to
-    # get its number.
-    for index in range(len(relevant_buffer) - 1, 0, -1):
-        line = relevant_buffer[index]
-        if re.findall(ISSUE_START, line):
-            issue_number = int(re.findall(r"\d+", line)[0])
-
-            break
-
-    # Add new issue lines, and set them, and move the cursor to the end.
     new_line_number = schedule_header_index
 
-    issue_start = f"{HEADING_2} {EMPTY_TODO} Issue {{{issue_number + 1}}}: +new"
+    issue_start = f"{HEADING_2} {EMPTY_TODO} Issue {{00}}: +new"
     title_line = f"{HEADING_3} Title: "
     comment_line = f"{HEADING_3} Comment {{0}}:"
     new_comment = [
@@ -193,6 +180,7 @@ def insert_new_comment(nvim):
     new_cursor_pos = (new_line_number + 2, 0)
     nvim.current.window.cursor = new_cursor_pos
 
+
 def check_markdown_style(line, desired_style):
     """check_markdown_style
 
@@ -208,6 +196,7 @@ def check_markdown_style(line, desired_style):
         return vimwiki_to_github_process(line)
     else:
         raise "Unknown style."
+
 
 def vimwiki_to_github_process(line):
     """vimwiki_to_github_process
@@ -228,6 +217,7 @@ def vimwiki_to_github_process(line):
 
     return line
 
+
 def github_to_vimwiki_process(line):
     """github_to_vimwiki_process
 
@@ -241,6 +231,7 @@ def github_to_vimwiki_process(line):
         line = line.replace(GITHUB_TODO, VIMWIKI_TODO)
 
     return line
+
 
 def convert_utc_timezone(datetime, target):
     """convert_utc_timezone

--- a/rplugin/python3/nvim_diary_template/plugin.py
+++ b/rplugin/python3/nvim_diary_template/plugin.py
@@ -58,6 +58,11 @@ class DiaryTemplatePlugin(object):
     @neovim.command('DiaryMake')
     # @if_active
     def make_diary(self, called_from_autocommand=False):
+        if self._options is None:
+            self._options = PluginOptions(self._nvim)
+            self._gcal_service = SimpleNvimGoogleCal(self._nvim, self._options)
+            self._github_service = SimpleNvimGithub(self._nvim, self._options)
+
         make_todays_diary(
             self._nvim,
             self._options,
@@ -115,8 +120,8 @@ class DiaryTemplatePlugin(object):
     @neovim.command('DiaryUploadNew')
     def upload_new_issues(self):
         issues = parse_markdown_file_for_issues(self._nvim)
-        self._github_service.upload_issues(issues, 'new')
-        self._github_service.upload_comments(issues, 'new')
+        issues = self._github_service.upload_issues(issues, 'new')
+        issues = self._github_service.upload_comments(issues, 'new')
         issues_without_new_tag = remove_tag_from_issues(issues, 'new')
         set_issues_from_issues_list(self._nvim, issues_without_new_tag)
 

--- a/rplugin/python3/nvim_diary_template/plugin.py
+++ b/rplugin/python3/nvim_diary_template/plugin.py
@@ -58,11 +58,6 @@ class DiaryTemplatePlugin(object):
     @neovim.command('DiaryMake')
     # @if_active
     def make_diary(self, called_from_autocommand=False):
-        if self._options is None:
-            self._options = PluginOptions(self._nvim)
-            self._gcal_service = SimpleNvimGoogleCal(self._nvim, self._options)
-            self._github_service = SimpleNvimGithub(self._nvim, self._options)
-
         make_todays_diary(
             self._nvim,
             self._options,

--- a/rplugin/python3/nvim_diary_template/plugin.py
+++ b/rplugin/python3/nvim_diary_template/plugin.py
@@ -120,15 +120,17 @@ class DiaryTemplatePlugin(object):
     @neovim.command('DiaryUploadNew')
     def upload_new_issues(self):
         issues = parse_markdown_file_for_issues(self._nvim)
+
         issues = self._github_service.upload_issues(issues, 'new')
         issues = self._github_service.upload_comments(issues, 'new')
+
         issues_without_new_tag = remove_tag_from_issues(issues, 'new')
         set_issues_from_issues_list(self._nvim, issues_without_new_tag)
 
     @neovim.command('DiaryUploadEdits')
     def upload_edited_issues(self):
         issues = parse_markdown_file_for_issues(self._nvim)
-        self._github_service.update_comments(issues, 'edit')
+        issues = self._github_service.update_comments(issues, 'edit')
 
         issues_without_edit_tag = remove_tag_from_issues(issues, 'edit')
         set_issues_from_issues_list(self._nvim, issues_without_edit_tag)

--- a/rplugin/python3/nvim_diary_template/utils/make_issues.py
+++ b/rplugin/python3/nvim_diary_template/utils/make_issues.py
@@ -7,7 +7,8 @@ from nvim_diary_template.helpers.issue_helpers import check_markdown_style
 from nvim_diary_template.helpers.neovim_helpers import (get_buffer_contents,
                                                         get_section_line)
 from nvim_diary_template.utils.constants import (EMPTY_TODO, HEADING_2,
-                                                 HEADING_3, ISSUE_HEADING)
+                                                 HEADING_3, ISSUE_HEADING,
+                                                 VIMWIKI_TODO)
 
 
 def format_issues(issues):
@@ -25,9 +26,14 @@ def format_issues(issues):
         issue_comments = issue['all_comments']
         issue_number = issue['number']
         issue_labels = issue['labels']
+        issue_complete = issue['complete']
 
         # TODO: Similarly, make this string into a config option.
-        issue_start = f"{HEADING_2} {EMPTY_TODO} Issue {{{issue_number}}}: "
+        if issue_complete:
+            issue_start = f"{HEADING_2} {VIMWIKI_TODO} Issue {{{issue_number}}}: "
+        else:
+            issue_start = f"{HEADING_2} {EMPTY_TODO} Issue {{{issue_number}}}: "
+
         title_line = f"{HEADING_3} Title: {issue_title}"
 
         # Apply the labels, before stripping to remove extra whitespace

--- a/rplugin/python3/nvim_diary_template/utils/make_schedule.py
+++ b/rplugin/python3/nvim_diary_template/utils/make_schedule.py
@@ -43,9 +43,8 @@ def produce_schedule_markdown(event_list):
 
     markdown_lines = []
 
-    # TODO: Should probably swap this to be a config option,
-    # something like f"{importance * #}".
     markdown_lines.append(SCHEDULE_HEADING)
+    markdown_lines.append("")
 
     converted_events = convert_events(event_list, TIME_FORMAT)
     schedule_lines = format_events_lines(converted_events)

--- a/rplugin/python3/nvim_diary_template/utils/nvim_github_class.py
+++ b/rplugin/python3/nvim_diary_template/utils/nvim_github_class.py
@@ -262,6 +262,10 @@ class SimpleNvimGithub():
                 .create_issue(title=issue_title, body=issue_body)
 
             issues[index]['number'] = new_issue.number
+            issues[index]['all_comments'][0]['updated_at'] = convert_utc_timezone(
+                new_issue.updated_at,
+                self.options.timezone
+            )
 
         return issues
 
@@ -307,6 +311,7 @@ class SimpleNvimGithub():
                 self.options.timezone
             )
 
+        return issues
 
     def complete_issues(self, issues):
         """complete_issues

--- a/rplugin/python3/nvim_diary_template/utils/nvim_github_class.py
+++ b/rplugin/python3/nvim_diary_template/utils/nvim_github_class.py
@@ -102,6 +102,7 @@ class SimpleNvimGithub():
         for issue in issues:
             issue_list.append({
                 'number': issue.number,
+                'complete': False,
                 'title': issue.title,
                 'body': issue.body,
                 'updated_at': convert_utc_timezone(

--- a/rplugin/python3/nvim_diary_template/utils/nvim_github_class.py
+++ b/rplugin/python3/nvim_diary_template/utils/nvim_github_class.py
@@ -172,9 +172,10 @@ class SimpleNvimGithub():
         """
 
         comments_to_upload = []
+        change_indexes = []
 
-        for issue in issues:
-            for comment in issue['all_comments']:
+        for issue_index, issue in enumerate(issues):
+            for comment_index, comment in enumerate(issue['all_comments']):
                 if tag in comment['comment_tags']:
                     comment_lines = comment['comment_lines']
                     processed_comment_lines = [
@@ -187,7 +188,12 @@ class SimpleNvimGithub():
                         'comment': '\r\n'.join(processed_comment_lines)
                     })
 
-        return comments_to_upload
+                    change_indexes.append({
+                        'issue': issue_index,
+                        'comment': comment_index
+                    })
+
+        return comments_to_upload, change_indexes
 
     @staticmethod
     def filter_issues(issues, tag):
@@ -197,8 +203,9 @@ class SimpleNvimGithub():
         """
 
         issues_to_upload = []
+        change_indexes = []
 
-        for issue in issues:
+        for index, issue in enumerate(issues):
             if tag in issue['metadata']:
                 issue_body = issue['all_comments'][0]['comment_lines']
                 processed_body = [
@@ -210,7 +217,9 @@ class SimpleNvimGithub():
                     'body': '\r\n'.join(processed_body)
                 })
 
-        return issues_to_upload
+                change_indexes.append(index)
+
+        return issues_to_upload, change_indexes
 
     def upload_comments(self, issues, tag):
         """upload_comments
@@ -218,15 +227,24 @@ class SimpleNvimGithub():
         Upload comments with the specific tag to GitHub.
         """
 
-        comments_to_upload = self.filter_comments(issues, tag)
+        comments_to_upload, change_indexes = self.filter_comments(issues, tag)
 
-        for comment in comments_to_upload:
+        for comment, change_index in zip(comments_to_upload, change_indexes):
             issue_number = comment['issue_number']
             comment_body = comment['comment']
 
-            self.service.get_repo(self.repo_name) \
-                        .get_issue(issue_number) \
-                        .create_comment(comment_body)
+            new_comment = self.service.get_repo(self.repo_name) \
+                .get_issue(issue_number) \
+                .create_comment(comment_body)
+
+            current_issue = issues[change_index['issue']]
+            current_comment = current_issue['all_comments'][change_index['comment']]
+            current_comment['updated_at'] = convert_utc_timezone(
+                new_comment.updated_at,
+                self.options.timezone
+            )
+
+        return issues
 
     def upload_issues(self, issues, tag):
         """upload_issues
@@ -234,14 +252,18 @@ class SimpleNvimGithub():
         Upload issues with the specific tag to GitHub.
         """
 
-        issues_to_upload = self.filter_issues(issues, tag)
+        issues_to_upload, change_indexes = self.filter_issues(issues, tag)
 
-        for issue in issues_to_upload:
+        for issue, index in zip(issues_to_upload, change_indexes):
             issue_title = issue['issue_title']
             issue_body = issue['body']
 
-            self.service.get_repo(self.repo_name) \
-                        .create_issue(title=issue_title, body=issue_body)
+            new_issue = self.service.get_repo(self.repo_name) \
+                .create_issue(title=issue_title, body=issue_body)
+
+            issues[index]['number'] = new_issue.number
+
+        return issues
 
     def update_comments(self, issues, tag):
         """update_comments
@@ -249,13 +271,12 @@ class SimpleNvimGithub():
         Update existing comments with the specific tag to GitHub.
         """
 
-        comments_to_upload = self.filter_comments(issues, tag)
+        comments_to_upload, change_indexes = self.filter_comments(issues, tag)
 
-        for comment in comments_to_upload:
+        for comment, change_index in zip(comments_to_upload, change_indexes):
             issue_number = comment['issue_number']
             comment_number = comment['comment_number']
             comment_body = comment['comment']
-
 
             # Comment 0 is actually the issue body, not a comment.
             if comment_number == 0:
@@ -267,11 +288,25 @@ class SimpleNvimGithub():
                 continue
 
             github_comment = self.service \
-                                    .get_repo(self.repo_name) \
-                                    .get_issue(issue_number) \
-                                    .get_comments()[comment_number - 1]
+                .get_repo(self.repo_name) \
+                .get_issue(issue_number) \
+                .get_comments()[comment_number - 1]
 
             github_comment.edit(comment_body)
+
+            # Grab the comment again, to sort the update time.
+            github_comment = self.service \
+                .get_repo(self.repo_name) \
+                .get_issue(issue_number) \
+                .get_comments()[comment_number - 1]
+
+            current_issue = issues[change_index['issue']]
+            current_comment = current_issue['all_comments'][change_index['comment']]
+            current_comment['updated_at'] = convert_utc_timezone(
+                github_comment.updated_at,
+                self.options.timezone
+            )
+
 
     def complete_issues(self, issues):
         """complete_issues

--- a/rplugin/python3/nvim_diary_template/utils/parse_markdown.py
+++ b/rplugin/python3/nvim_diary_template/utils/parse_markdown.py
@@ -101,9 +101,9 @@ def parse_buffer_issues(issue_lines):
                 'number': int(re.findall(r"\d+", line)[0]),
                 'title': '',
                 'metadata': metadata,
+                'labels': labels,
                 'complete': re.search(TODO_IS_CHECKED, line) != None,
                 'all_comments': [],
-                'labels': labels,
             })
 
             continue


### PR DESCRIPTION
Previously, we just assumed the new issue would be the next number along, ie if the buffer has issue 1, the next is 2. This was a bit confusing  to find issues on the GitHub side, as due to closed issues the new issue could actually be issue 10 etc.

Also now update the timestamps on uploads.