### PR TITLE
Swap issue upload to use the latest update time.

### DIFF
--- a/rplugin/python3/nvim_diary_template/classes/nvim_github_class.py
+++ b/rplugin/python3/nvim_diary_template/classes/nvim_github_class.py
@@ -19,6 +19,7 @@ from ..helpers.issue_helpers import (
     check_markdown_style,
     convert_utc_timezone,
     get_github_objects,
+    get_latest_update,
     split_comment,
 )
 from ..helpers.neovim_helpers import buffered_info_message
@@ -288,11 +289,14 @@ class SimpleNvimGithub:
                     check_markdown_style(line, "github") for line in comment.body
                 ]
 
+                # Here, we use the latest update time to ensure that the issues are in sync.
+                # Since the actual update time isn't needed for an issue update, this is why
+                # it is instead stored here.
                 body_comment: GitHubIssueComment = GitHubIssueComment(
                     number=comment.number,
                     body=["\r\n".join(processed_body)],
                     tags=comment.tags,
-                    updated_at=comment.updated_at,
+                    updated_at=get_latest_update(issue.all_comments),
                 )
 
                 issues_to_upload.append(

--- a/rplugin/python3/nvim_diary_template/helpers/issue_helpers.py
+++ b/rplugin/python3/nvim_diary_template/helpers/issue_helpers.py
@@ -4,9 +4,9 @@ Simple helpers to deal with Github issues.
 """
 import re
 from datetime import datetime
-from typing import Any, Dict, List, Tuple, Union, Optional
+from typing import Any, Dict, List, Optional, Tuple, Union
 
-from dateutil import tz
+from dateutil import parser, tz
 from neovim import Nvim
 
 from ..classes.github_issue_class import GitHubIssue, GitHubIssueComment
@@ -282,6 +282,21 @@ def convert_utc_timezone(passed_datetime: datetime, target: str) -> str:
     utc_time: datetime = passed_datetime.replace(tzinfo=tz.tzutc())
 
     return utc_time.astimezone(tz.gettz(target)).strftime("%Y-%m-%d %H:%M")
+
+
+def get_latest_update(comments: List[GitHubIssueComment]) -> str:
+    """get_latest_update
+
+    Get the latest update for an issue, that is the latest updated comment.
+    """
+
+    latest_update: str = comments[0].updated_at
+
+    for comment in comments:
+        if parser.parse(latest_update) < parser.parse(comment.updated_at):
+            latest_update = comment.updated_at
+
+    return latest_update
 
 
 def sort_issues(issues: List[GitHubIssue]) -> List[GitHubIssue]:

--- a/rplugin/python3/nvim_diary_template/tests/test_issue_helpers.py
+++ b/rplugin/python3/nvim_diary_template/tests/test_issue_helpers.py
@@ -9,6 +9,7 @@ from ..classes.github_issue_class import GitHubIssue, GitHubIssueComment
 from ..helpers.issue_helpers import (
     check_markdown_style,
     get_github_objects,
+    get_latest_update,
     insert_edit_tag,
     insert_new_comment,
     insert_new_issue,
@@ -418,6 +419,39 @@ class issue_helpersTest(unittest.TestCase):
         # Check objects are left alone.
         result = get_github_objects(converted_dicts)
         assert result == converted_dicts
+
+    def test_get_latest_update(self) -> None:
+        inital_issue: GitHubIssue = GitHubIssue(
+            number=1,
+            title="Test Issue 1",
+            complete=False,
+            labels=["inprogress", "work"],
+            all_comments=[
+                GitHubIssueComment(
+                    number=0,
+                    body=["Line 1", "Line 2"],
+                    tags=[],
+                    updated_at="2018-08-19 18:18",
+                ),
+                GitHubIssueComment(
+                    number=1,
+                    body=["Line 2-1", "Line 2-2"],
+                    tags=[],
+                    updated_at="2018-12-19 12:18",
+                ),
+                GitHubIssueComment(
+                    number=1,
+                    body=["Line 3-1", "Line 3-2"],
+                    tags=[],
+                    updated_at="2018-08-19 12:18",
+                ),
+            ],
+            metadata=[],
+        )
+        expected_date: str = "2018-12-19 12:18"
+
+        result: str = get_latest_update(inital_issue.all_comments)
+        assert result == expected_date
 
     def test_split_comment(self) -> None:
         initial_comment: str = "\nThis is comments line 1.\nAnd this is line 2.\nAnd the line 3!\n\n"

--- a/rplugin/python3/nvim_diary_template/tests/test_nvim_github_class.py
+++ b/rplugin/python3/nvim_diary_template/tests/test_nvim_github_class.py
@@ -127,7 +127,7 @@ class SimpleNvimGithubTest(unittest.TestCase):
                             "This is the second issue body:\r\n    * Item 1\r\n    * Item 2"
                         ],
                         tags=[],
-                        updated_at="2018-01-01 10:00",
+                        updated_at="2018-08-19 19:18",
                     )
                 ],
             )


### PR DESCRIPTION
Before we always assumed the first issue was the latest to be updated, which is incorrect. Now always find the latest, to check against the GitHub latest update.