### PR TITLE
Add workaround for recurring events.

### DIFF
--- a/rplugin/python3/nvim_diary_template/helpers/google_calendar_helpers.py
+++ b/rplugin/python3/nvim_diary_template/helpers/google_calendar_helpers.py
@@ -68,8 +68,14 @@ def format_google_events(
             event_end = event["end"]["date"]
 
         event_date: str = str(get_time(event_start).date())
+        recursed_event: bool = "recurrence" in event and event["recurrence"] != []
 
-        if event_date != diary_date:
+        # If its an event not from today, then don't show it.
+        # This is needed since it can return some late events somehow.
+        # Additionally, we just have to trust that a recurring event is today.
+        # This is because the start date is set to the date of the first event,
+        # not the current event instance.
+        if event_date != diary_date and not recursed_event:
             continue
 
         filtered_events.append(


### PR DESCRIPTION
Recurring events are returned from the GCal API with their start and end dates set to the same as the original for whatever reason (its outlined in the docs that this is the case, but who knows why).

For now, lets just hope that a recurring event doesn't happen at a time that confuses the checker, and ignore skipping it.