### PR TITLE
Fix recurring events.

### DIFF
--- a/rplugin/python3/nvim_diary_template/classes/nvim_google_cal_class.py
+++ b/rplugin/python3/nvim_diary_template/classes/nvim_google_cal_class.py
@@ -169,6 +169,7 @@ class SimpleNvimGoogleCal:
                     pageToken=page_token,
                     timeMin=time_min,
                     timeMax=time_max,
+                    singleEvents=True,
                 )
                 .execute()
             )

--- a/rplugin/python3/nvim_diary_template/helpers/google_calendar_helpers.py
+++ b/rplugin/python3/nvim_diary_template/helpers/google_calendar_helpers.py
@@ -68,14 +68,10 @@ def format_google_events(
             event_end = event["end"]["date"]
 
         event_date: str = str(get_time(event_start).date())
-        recursed_event: bool = "recurrence" in event and event["recurrence"] != []
 
         # If its an event not from today, then don't show it.
         # This is needed since it can return some late events somehow.
-        # Additionally, we just have to trust that a recurring event is today.
-        # This is because the start date is set to the date of the first event,
-        # not the current event instance.
-        if event_date != diary_date and not recursed_event:
+        if event_date != diary_date:
             continue
 
         filtered_events.append(


### PR DESCRIPTION
This PR turns on the "singleEvents" option that makes a recurring event have the "correct" (in my mind) date of the actual event date, rather than the date of the first event in a series of events.