### PR TITLE
Make issue sort order a config option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ reminder where and how things are setup.
     - Issues you make online and in-diary are synced, along with all
       comments.
     - Support for Github labels (including Deoplete source), including sorting
-      by labels (needs config adding for this, currently a set sort order).
+      by labels.
 - Diary outline generation:
     - Builds a diary file with metadata in and the defined headings.
 
@@ -124,4 +124,24 @@ The heading list (outside of Issues and Schedule), can be set with:
 
 ```viml
 let g:nvim_diary_template#daily_headings = ["Notes", "Meetings"]
+```
+
+The issue sort order is based on the labels that a given issue has, as well
+as the completion state. The highest number for a given issue is used to sort
+it.
+
+The `issue.complete` value is assigned to any completed issue.
+
+Issues are sorted such that the lower the score, the higher it appears on the
+list. That is, with the default settings, completed issues are at the bottom
+and in progress issues are at the top.
+
+```viml
+let g:nvim_diary_template#sort_order = {
+            \ "issue.complete": 10000,
+            \ "backlog": 5000,
+            \ "blocked": 1000,
+            \ "default": 100,
+            \ "inprogress": 0,
+            \ }
 ```

--- a/rplugin/python3/nvim_diary_template/classes/plugin_options.py
+++ b/rplugin/python3/nvim_diary_template/classes/plugin_options.py
@@ -7,8 +7,11 @@ well as any associated helpers.
 
 import os
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
+
 from neovim import Nvim
+
+from ..utils.constants import DEFAULT_SORT_ORDER
 
 
 class PluginOptions:
@@ -37,6 +40,7 @@ class PluginOptions:
         self.repo_name: str = ""
         self.user_name: str = ""
         self.sort_issues_on_upload: bool = False
+        self.sort_order: Dict[str, int] = DEFAULT_SORT_ORDER
 
         if nvim is not None:
             for key, default_value in self.__dict__.items():

--- a/rplugin/python3/nvim_diary_template/plugin.py
+++ b/rplugin/python3/nvim_diary_template/plugin.py
@@ -111,12 +111,12 @@ class DiaryTemplatePlugin:
             self._nvim, markdown_issues, github_issues
         )
 
-        set_issues_from_issues_list(self._nvim, combined_issues, True)
+        set_issues_from_issues_list(self._nvim, self.options, combined_issues, True)
 
     @neovim.command("DiarySortIssues")
     def sort_issues(self) -> None:
         markdown_issues: List[GitHubIssue] = parse_markdown_file_for_issues(self._nvim)
-        set_issues_from_issues_list(self._nvim, markdown_issues, True)
+        set_issues_from_issues_list(self._nvim, self.options, markdown_issues, True)
 
     @neovim.command("DiaryInsertIssue")
     def insert_issue(self) -> None:
@@ -149,7 +149,10 @@ class DiaryTemplatePlugin:
         )
 
         set_issues_from_issues_list(
-            self._nvim, issues_without_new_tag, self.options.sort_issues_on_upload
+            self._nvim,
+            self.options,
+            issues_without_new_tag,
+            self.options.sort_issues_on_upload,
         )
 
         if not buffered:
@@ -168,7 +171,10 @@ class DiaryTemplatePlugin:
         )
 
         set_issues_from_issues_list(
-            self._nvim, issues_without_edit_tag, self.options.sort_issues_on_upload
+            self._nvim,
+            self.options,
+            issues_without_edit_tag,
+            self.options.sort_issues_on_upload,
         )
 
         if not buffered:
@@ -186,7 +192,7 @@ class DiaryTemplatePlugin:
         # Despite no changes happening here, we want to set the issues again to
         # sort them.
         set_issues_from_issues_list(
-            self._nvim, issues, self.options.sort_issues_on_upload
+            self._nvim, self.options, issues, self.options.sort_issues_on_upload
         )
 
         if not buffered:

--- a/rplugin/python3/nvim_diary_template/tests/test_issue_helpers.py
+++ b/rplugin/python3/nvim_diary_template/tests/test_issue_helpers.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List
 import pytest
 
 from ..classes.github_issue_class import GitHubIssue, GitHubIssueComment
+from ..classes.plugin_options import PluginOptions
 from ..helpers.issue_helpers import (
     check_markdown_style,
     get_github_objects,
@@ -26,6 +27,7 @@ class issue_helpersTest(unittest.TestCase):
 
     def setUp(self) -> None:
         self.nvim: MockNvim = MockNvim()
+        self.options: PluginOptions = PluginOptions()
         self.nvim.current.buffer.lines = [
             "<!---",
             "    Date: 2018-01-01",
@@ -329,7 +331,7 @@ class issue_helpersTest(unittest.TestCase):
             deepcopy(issue_2),
         ]
 
-        result: List[GitHubIssue] = sort_issues(unsorted_list)
+        result: List[GitHubIssue] = sort_issues(self.options, unsorted_list)
         assert result == sorted_list
 
     def test_get_github_objects(self) -> None:

--- a/rplugin/python3/nvim_diary_template/tests/test_make_issues.py
+++ b/rplugin/python3/nvim_diary_template/tests/test_make_issues.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 from typing import Dict, List
 
 from ..classes.github_issue_class import GitHubIssue, GitHubIssueComment
+from ..classes.plugin_options import PluginOptions
 from ..utils.make_issues import (
     produce_issue_markdown,
     remove_tag_from_issues,
@@ -18,6 +19,7 @@ class make_issuesTest(unittest.TestCase):
 
     def setUp(self) -> None:
         self.nvim = MockNvim()
+        self.options = PluginOptions()
         self.set_buffer()
 
         self.issues: List[GitHubIssue] = [
@@ -125,7 +127,7 @@ class make_issuesTest(unittest.TestCase):
             "",
         ]
 
-        result: List[str] = produce_issue_markdown(self.issues)
+        result: List[str] = produce_issue_markdown(self.options, self.issues)
         assert result == final_buffer
 
     def test_remove_tag_from_issues(self) -> None:
@@ -196,7 +198,7 @@ class make_issuesTest(unittest.TestCase):
         ]
 
         # Check buffer is properly set.
-        set_issues_from_issues_list(self.nvim, self.issues, True)
+        set_issues_from_issues_list(self.nvim, self.options, self.issues, True)
         assert self.nvim.current.buffer.lines == final_buffer
 
         final_buffer = [
@@ -244,5 +246,5 @@ class make_issuesTest(unittest.TestCase):
 
         # Check sorting works.
         self.set_buffer()
-        set_issues_from_issues_list(self.nvim, self.issues, False)
+        set_issues_from_issues_list(self.nvim, self.options, self.issues, False)
         assert self.nvim.current.buffer.lines == final_buffer

--- a/rplugin/python3/nvim_diary_template/utils/constants.py
+++ b/rplugin/python3/nvim_diary_template/utils/constants.py
@@ -71,6 +71,6 @@ DEFAULT_SORT_ORDER = {
     "issue.complete": 10000,
     "backlog": 5000,
     "blocked": 1000,
-    "inprogress": 0,
     "default": 100,
+    "inprogress": 0,
 }

--- a/rplugin/python3/nvim_diary_template/utils/constants.py
+++ b/rplugin/python3/nvim_diary_template/utils/constants.py
@@ -36,6 +36,7 @@ TODO_IN_PROGRESS_REGEX = r"\[[.oO]\]"
 GITHUB_TODO = "[x]"
 VIMWIKI_TODO = "[X]"
 
+# Issue related Regex
 ISSUE_START = r"^### \[[ X]\] Issue \{[0-9]+\}:"
 ISSUE_TITLE = r"^#### Title: "
 ISSUE_COMMENT = (
@@ -44,11 +45,12 @@ ISSUE_COMMENT = (
 ISSUE_METADATA = r"\+[a-zA-Z0-9]+"
 ISSUE_LABELS = r"\+label:[a-zA-Z0-9]+"
 
+# Event related Regex
 EVENT_REGEX = r"(?<=: ).*$"
 CALENDAR_REGEX = r"{cal:(.+)}"
 
+# Markdown related
 HEADING_REGEX = r"^## .*"
-
 BULLET_POINT_REGEX = r"[ ]*?-"
 
 # Markdown Constants
@@ -62,3 +64,13 @@ PADDING = "    "
 PADDING_SIZE = 4
 EMPTY_TODO = "[ ]"
 BULLET_POINT = "-"
+
+# Options
+
+DEFAULT_SORT_ORDER = {
+    "issue.complete": 10000,
+    "backlog": 5000,
+    "blocked": 1000,
+    "inprogess": 0,
+    "default": 100,
+}

--- a/rplugin/python3/nvim_diary_template/utils/constants.py
+++ b/rplugin/python3/nvim_diary_template/utils/constants.py
@@ -71,6 +71,6 @@ DEFAULT_SORT_ORDER = {
     "issue.complete": 10000,
     "backlog": 5000,
     "blocked": 1000,
-    "inprogess": 0,
+    "inprogress": 0,
     "default": 100,
 }

--- a/rplugin/python3/nvim_diary_template/utils/make_issues.py
+++ b/rplugin/python3/nvim_diary_template/utils/make_issues.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Optional, Union
 from neovim import Nvim
 
 from ..classes.github_issue_class import GitHubIssue, GitHubIssueComment
+from ..classes.plugin_options import PluginOptions
 from ..helpers.issue_helpers import check_markdown_style, sort_issues
 from ..helpers.neovim_helpers import get_buffer_contents, get_section_line
 from ..utils.constants import (
@@ -19,7 +20,9 @@ from ..utils.constants import (
 )
 
 
-def format_issues(issues: List[GitHubIssue], should_sort: bool) -> List[str]:
+def format_issues(
+    options: PluginOptions, issues: List[GitHubIssue], should_sort: bool
+) -> List[str]:
     """format_issues
 
     Given some issues, will produce formatted lines for them.
@@ -28,7 +31,7 @@ def format_issues(issues: List[GitHubIssue], should_sort: bool) -> List[str]:
     issue_lines: List[str] = []
 
     if should_sort:
-        issues = sort_issues(issues)
+        issues = sort_issues(options, issues)
 
     # For every issue, format it into markdown lines that are easily read.
     for issue in issues:
@@ -92,7 +95,9 @@ def format_issue_comments(comments: List[GitHubIssueComment]) -> List[str]:
     return formatted_comments
 
 
-def produce_issue_markdown(issue_list: List[GitHubIssue]) -> List[str]:
+def produce_issue_markdown(
+    options: PluginOptions, issue_list: List[GitHubIssue]
+) -> List[str]:
     """produce_issue_markdown
 
     Given a list of issues, will produce a basic bit of markdown
@@ -101,7 +106,7 @@ def produce_issue_markdown(issue_list: List[GitHubIssue]) -> List[str]:
 
     markdown_lines: List[str] = [ISSUE_HEADING, ""]
 
-    issue_lines: List[str] = format_issues(issue_list, True)
+    issue_lines: List[str] = format_issues(options, issue_list, True)
     markdown_lines.extend(issue_lines)
 
     return markdown_lines
@@ -152,7 +157,7 @@ def remove_tag_from_issues(
 
 
 def set_issues_from_issues_list(
-    nvim: Nvim, issues: List[GitHubIssue], should_sort: bool
+    nvim: Nvim, options: PluginOptions, issues: List[GitHubIssue], should_sort: bool
 ) -> None:
     """set_issues_from_issues_list
 
@@ -160,7 +165,7 @@ def set_issues_from_issues_list(
     """
 
     # Get the formatted lines to set.
-    issue_lines: List[str] = format_issues(issues, should_sort)
+    issue_lines: List[str] = format_issues(options, issues, should_sort)
 
     buffer_number: int = nvim.current.buffer.number
     current_buffer: List[str] = get_buffer_contents(nvim)

--- a/rplugin/python3/nvim_diary_template/utils/make_markdown_file.py
+++ b/rplugin/python3/nvim_diary_template/utils/make_markdown_file.py
@@ -68,7 +68,7 @@ def make_diary(
     if options.use_github_repo and github_service and github_service.active:
         issues = github_service.active_issues
 
-    issue_markdown: List[str] = produce_issue_markdown(issues)
+    issue_markdown: List[str] = produce_issue_markdown(options, issues)
     full_markdown.extend(issue_markdown)
 
     # Add in that days calendar entries


### PR DESCRIPTION
Was becoming a pain to have a fixed order with no way of changing it, so this lets a vim script dictionary be used to specify the scores needed for a given label.