### PR TITLE
Grouped Issues Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,11 @@ let g:nvim_diary_template#sort_order = {
 ```
 
 The issue grouping (i.e. add a subheading under issues for certain issues, and
-"Other" for the remaining) can be set with
+"Other" for the remaining) can be set with the following
 
 ```viml
-let g:nvim_diary_template#issue_groups = ['work', 'personal']
+let g:nvim_diary_template#issue_groups = [['work', 'personal']]
 ```
+
+Where this is a list of lists, for alternative sorting methods. Calling
+`:DiarySwapGroupSorting` will move to the next sorting style.

--- a/rplugin/python3/nvim_diary_template/classes/plugin_options.py
+++ b/rplugin/python3/nvim_diary_template/classes/plugin_options.py
@@ -33,7 +33,7 @@ class PluginOptions:
         self.auto_generate_diary_index = False
         self.use_google_calendar: bool = True
         self.calendar_filter_list: List[str] = []
-        self.issue_groups: List[str] = []
+        self.issue_groups: List[List[str]] = [[]]
         self.add_to_google_cal: bool = False
         self.google_cal_name: str = "primary"
         self.timezone: str = "Europe/London"

--- a/rplugin/python3/nvim_diary_template/helpers/issue_helpers.py
+++ b/rplugin/python3/nvim_diary_template/helpers/issue_helpers.py
@@ -13,6 +13,7 @@ from ..classes.github_issue_class import GitHubIssue, GitHubIssueComment
 from ..classes.plugin_options import PluginOptions
 from ..helpers.neovim_helpers import (
     get_buffer_contents,
+    get_next_heading_of_level,
     get_section_line,
     set_line_content,
 )
@@ -26,6 +27,7 @@ from ..utils.constants import (
     ISSUE_START,
     SCHEDULE_HEADING,
     SUBGROUP_HEADING,
+    SUBGROUP_HEADING_LEVEL,
     TODO_IN_PROGRESS_REGEX,
     VIMWIKI_TODO,
 )
@@ -91,8 +93,19 @@ def insert_new_issue(nvim: Nvim) -> None:
     """
 
     # Grab the indexes needed to find the issue we are in.
+    current_cursor_pos: int = nvim.current.window.cursor[0]
     current_buffer: List[str] = get_buffer_contents(nvim)
-    new_line_number: int = get_section_line(current_buffer, SCHEDULE_HEADING) - 1
+
+    issue_heading: int = get_section_line(current_buffer, ISSUE_HEADING)
+    schedule_heading: int = get_section_line(current_buffer, SCHEDULE_HEADING)
+
+    if current_cursor_pos < issue_heading:
+        new_line_number = schedule_heading - 1
+    else:
+        offset: int = get_next_heading_of_level(
+            current_buffer[current_cursor_pos:], SUBGROUP_HEADING_LEVEL
+        )
+        new_line_number = current_cursor_pos + offset
 
     issue_start: str = f"{HEADING_4} {EMPTY_TODO} Issue {{00}}: +new"
     title_line: str = f"{HEADING_5} Title: "

--- a/rplugin/python3/nvim_diary_template/helpers/issue_helpers.py
+++ b/rplugin/python3/nvim_diary_template/helpers/issue_helpers.py
@@ -25,6 +25,7 @@ from ..utils.constants import (
     ISSUE_HEADING,
     ISSUE_START,
     SCHEDULE_HEADING,
+    SUBGROUP_HEADING,
     TODO_IN_PROGRESS_REGEX,
     VIMWIKI_TODO,
 )
@@ -128,10 +129,11 @@ def insert_new_comment(nvim: Nvim) -> None:
     relevant_buffer: List[str] = current_buffer[current_line:schedule_header_index]
     new_line_number: int = -1
 
-    # Search the buffer forwards and find the start of the next issue, to
-    # insert before it. Then, find the last comment number and increment it.
+    # Search the buffer forwards and find the start of the next issue, or the
+    # sub-group heading to insert before it. Then, find the last comment number
+    # and increment it.
     for index, line in enumerate(relevant_buffer):
-        if re.findall(ISSUE_START, line):
+        if re.findall(ISSUE_START, line) or re.findall(SUBGROUP_HEADING, line):
             new_line_number = index
 
             break

--- a/rplugin/python3/nvim_diary_template/plugin.py
+++ b/rplugin/python3/nvim_diary_template/plugin.py
@@ -1,7 +1,7 @@
 # pylint: disable=missing-docstring, W0201
 from datetime import date
 from functools import wraps
-from typing import Callable, List
+from typing import Any, Callable, List
 
 import neovim
 from dateutil import parser
@@ -205,6 +205,14 @@ class DiaryTemplatePlugin:
         self.upload_issue_completions(True)
 
         self.flush_messages()
+
+    @neovim.command("DiarySwapGroupSorting")
+    def swap_group_sorting(self) -> None:
+        def rotate(input_list: List[Any], pivot: int) -> List[Any]:
+            return input_list[pivot:] + input_list[:pivot]
+
+        self.options.issue_groups = rotate(self.options.issue_groups, 1)
+        self.sort_issues()
 
     def flush_messages(self) -> None:
         self._nvim.out_write("\n")

--- a/rplugin/python3/nvim_diary_template/tests/test_issue_helpers.py
+++ b/rplugin/python3/nvim_diary_template/tests/test_issue_helpers.py
@@ -46,6 +46,13 @@ class issue_helpersTest(unittest.TestCase):
             "##### Comment {0} - 2018-01-01 12:00:",
             "Test comment body.",
             "",
+            "#### [ ] Issue {2}: +label:personal",
+            "",
+            "##### Title: Test Issue 1",
+            "",
+            "##### Comment {0} - 2018-01-01 12:00:",
+            "Test comment body.",
+            "",
             "## Schedule",
             "",
             "",
@@ -64,6 +71,13 @@ class issue_helpersTest(unittest.TestCase):
             "## Issues",
             "",
             "#### [ ] Issue {1}: +label:work",
+            "",
+            "##### Title: Test Issue 1",
+            "",
+            "##### Comment {0} - 2018-01-01 12:00:",
+            "Test comment body.",
+            "",
+            "#### [ ] Issue {2}: +label:personal",
             "",
             "##### Title: Test Issue 1",
             "",
@@ -129,6 +143,13 @@ class issue_helpersTest(unittest.TestCase):
             "##### Comment {0} - 2018-01-01 12:00:",
             "Test comment body.",
             "",
+            "#### [ ] Issue {2}: +label:personal",
+            "",
+            "##### Title: Test Issue 1",
+            "",
+            "##### Comment {0} - 2018-01-01 12:00:",
+            "Test comment body.",
+            "",
             "#### [ ] Issue {00}: +new",
             "",
             "##### Title: ",
@@ -143,7 +164,7 @@ class issue_helpersTest(unittest.TestCase):
         # Check a new issue is added, and the cursor is moved correctly.
         insert_new_issue(self.nvim)
         assert self.nvim.current.buffer.lines == final_buffer
-        assert self.nvim.current.window.cursor == (20, 12)
+        assert self.nvim.current.window.cursor == (27, 12)
 
     def test_insert_new_comment(self) -> None:
         final_buffer: List[str] = [
@@ -166,6 +187,184 @@ class issue_helpersTest(unittest.TestCase):
             "",
             "##### Comment {1} - 0000-00-00 00:00: +new",
             "",
+            "",
+            "#### [ ] Issue {2}: +label:personal",
+            "",
+            "##### Title: Test Issue 1",
+            "",
+            "##### Comment {0} - 2018-01-01 12:00:",
+            "Test comment body.",
+            "",
+            "## Schedule",
+            "",
+            "",
+        ]
+
+        # Check the buffer doesn't change at first, since we aren't in an issue.
+        initial_buffer: List[str] = self.nvim.current.buffer.lines
+        insert_new_comment(self.nvim)
+        assert self.nvim.current.buffer.lines == initial_buffer
+        assert self.nvim.current.window.cursor == (0, 0)
+
+        # Now put the cursor in an issue, and check a new comment is added, and
+        # the cursor is moved correctly.
+        self.nvim.current.window.cursor = (13, 0)
+        insert_new_comment(self.nvim)
+        assert self.nvim.current.buffer.lines == final_buffer
+        assert self.nvim.current.window.cursor == (19, 0)
+
+    def test_insert_new_issue_in_group(self) -> None:
+        final_buffer: List[str] = [
+            "<!---",
+            "    Date: 2018-01-01",
+            "    Tags:",
+            "--->",
+            "# Diary for 2018-01-01",
+            "",
+            "## Notes",
+            "",
+            "## Issues",
+            "",
+            "### Work",
+            "",
+            "#### [ ] Issue {1}: +label:work",
+            "",
+            "##### Title: Test Issue 1",
+            "",
+            "##### Comment {0} - 2018-01-01 12:00:",
+            "Test comment body.",
+            "",
+            "### Personal",
+            "",
+            "#### [ ] Issue {2}: +label:personal",
+            "",
+            "##### Title: Test Issue 1",
+            "",
+            "##### Comment {0} - 2018-01-01 12:00:",
+            "Test comment body.",
+            "",
+            "#### [ ] Issue {00}: +new",
+            "",
+            "##### Title: ",
+            "",
+            "##### Comment {0} - 0000-00-00 00:00: +new",
+            "",
+            "## Schedule",
+            "",
+            "",
+        ]
+
+        # Set the buffer to contain groups.
+        self.options.issue_groups = ["work", "personal"]
+        self.nvim.current.buffer.lines = [
+            "<!---",
+            "    Date: 2018-01-01",
+            "    Tags:",
+            "--->",
+            "# Diary for 2018-01-01",
+            "",
+            "## Notes",
+            "",
+            "## Issues",
+            "",
+            "### Work",
+            "",
+            "#### [ ] Issue {1}: +label:work",
+            "",
+            "##### Title: Test Issue 1",
+            "",
+            "##### Comment {0} - 2018-01-01 12:00:",
+            "Test comment body.",
+            "",
+            "### Personal",
+            "",
+            "#### [ ] Issue {2}: +label:personal",
+            "",
+            "##### Title: Test Issue 1",
+            "",
+            "##### Comment {0} - 2018-01-01 12:00:",
+            "Test comment body.",
+            "",
+            "## Schedule",
+            "",
+            "",
+        ]
+
+        # Check a new issue is added, and the cursor is moved correctly.
+        insert_new_issue(self.nvim)
+        assert self.nvim.current.buffer.lines == final_buffer
+        assert self.nvim.current.window.cursor == (31, 12)
+
+    def test_insert_new_group_comment(self) -> None:
+        final_buffer: List[str] = [
+            "<!---",
+            "    Date: 2018-01-01",
+            "    Tags:",
+            "--->",
+            "# Diary for 2018-01-01",
+            "",
+            "## Notes",
+            "",
+            "## Issues",
+            "",
+            "### Work",
+            "",
+            "#### [ ] Issue {1}: +label:work",
+            "",
+            "##### Title: Test Issue 1",
+            "",
+            "##### Comment {0} - 2018-01-01 12:00:",
+            "Test comment body.",
+            "",
+            "##### Comment {1} - 0000-00-00 00:00: +new",
+            "",
+            "### Personal",
+            "",
+            "#### [ ] Issue {2}: +label:personal",
+            "",
+            "##### Title: Test Issue 1",
+            "",
+            "##### Comment {0} - 2018-01-01 12:00:",
+            "Test comment body.",
+            "",
+            "##### Comment {0} - 2018-01-01 12:00:",
+            "Test comment body.",
+            "",
+            "## Schedule",
+            "",
+            "",
+        ]
+
+        # Set the buffer to contain groups.
+        self.options.issue_groups = ["work", "personal"]
+        self.nvim.current.buffer.lines = [
+            "<!---",
+            "    Date: 2018-01-01",
+            "    Tags:",
+            "--->",
+            "# Diary for 2018-01-01",
+            "",
+            "## Notes",
+            "",
+            "## Issues",
+            "",
+            "### Work",
+            "",
+            "#### [ ] Issue {1}: +label:work",
+            "",
+            "##### Title: Test Issue 1",
+            "",
+            "##### Comment {0} - 2018-01-01 12:00:",
+            "Test comment body.",
+            "",
+            "### Personal",
+            "",
+            "#### [ ] Issue {2}: +label:personal",
+            "",
+            "##### Title: Test Issue 1",
+            "",
+            "##### Comment {0} - 2018-01-01 12:00:",
+            "Test comment body.",
             "",
             "## Schedule",
             "",
@@ -198,6 +397,13 @@ class issue_helpersTest(unittest.TestCase):
             "## Issues",
             "",
             "#### [ ] Issue {1}: +label:work",
+            "",
+            "##### Title: Test Issue 1",
+            "",
+            "##### Comment {0} - 2018-01-01 12:00:",
+            "Test comment body.",
+            "",
+            "#### [ ] Issue {2}: +label:personal",
             "",
             "##### Title: Test Issue 1",
             "",

--- a/rplugin/python3/nvim_diary_template/tests/test_issue_helpers.py
+++ b/rplugin/python3/nvim_diary_template/tests/test_issue_helpers.py
@@ -295,6 +295,90 @@ class issue_helpersTest(unittest.TestCase):
         assert self.nvim.current.buffer.lines == final_buffer
         assert self.nvim.current.window.cursor == (31, 12)
 
+        # Check that an issue is added in the correct subgroup
+        final_buffer = [
+            "<!---",
+            "    Date: 2018-01-01",
+            "    Tags:",
+            "--->",
+            "# Diary for 2018-01-01",
+            "",
+            "## Notes",
+            "",
+            "## Issues",
+            "",
+            "### Work",
+            "",
+            "#### [ ] Issue {1}: +label:work",
+            "",
+            "##### Title: Test Issue 1",
+            "",
+            "##### Comment {0} - 2018-01-01 12:00:",
+            "Test comment body.",
+            "",
+            "#### [ ] Issue {00}: +new",
+            "",
+            "##### Title: ",
+            "",
+            "##### Comment {0} - 0000-00-00 00:00: +new",
+            "",
+            "### Personal",
+            "",
+            "#### [ ] Issue {2}: +label:personal",
+            "",
+            "##### Title: Test Issue 1",
+            "",
+            "##### Comment {0} - 2018-01-01 12:00:",
+            "Test comment body.",
+            "",
+            "## Schedule",
+            "",
+            "",
+        ]
+
+        # Set the buffer to contain groups.
+        self.options.issue_groups = [["work", "personal"]]
+        self.nvim.current.buffer.lines = [
+            "<!---",
+            "    Date: 2018-01-01",
+            "    Tags:",
+            "--->",
+            "# Diary for 2018-01-01",
+            "",
+            "## Notes",
+            "",
+            "## Issues",
+            "",
+            "### Work",
+            "",
+            "#### [ ] Issue {1}: +label:work",
+            "",
+            "##### Title: Test Issue 1",
+            "",
+            "##### Comment {0} - 2018-01-01 12:00:",
+            "Test comment body.",
+            "",
+            "### Personal",
+            "",
+            "#### [ ] Issue {2}: +label:personal",
+            "",
+            "##### Title: Test Issue 1",
+            "",
+            "##### Comment {0} - 2018-01-01 12:00:",
+            "Test comment body.",
+            "",
+            "## Schedule",
+            "",
+            "",
+        ]
+
+        # Set the cursor inside the Work group, so an issue
+        # should be added there.
+        self.nvim.current.window.cursor = (12, 0)
+        insert_new_issue(self.nvim)
+        assert self.nvim.current.buffer.lines == final_buffer
+        # assert self.nvim.current.window.cursor == (31, 12)
+
     def test_insert_new_group_comment(self) -> None:
         final_buffer: List[str] = [
             "<!---",

--- a/rplugin/python3/nvim_diary_template/tests/test_issue_helpers.py
+++ b/rplugin/python3/nvim_diary_template/tests/test_issue_helpers.py
@@ -255,7 +255,7 @@ class issue_helpersTest(unittest.TestCase):
         ]
 
         # Set the buffer to contain groups.
-        self.options.issue_groups = ["work", "personal"]
+        self.options.issue_groups = [["work", "personal"]]
         self.nvim.current.buffer.lines = [
             "<!---",
             "    Date: 2018-01-01",
@@ -334,7 +334,7 @@ class issue_helpersTest(unittest.TestCase):
         ]
 
         # Set the buffer to contain groups.
-        self.options.issue_groups = ["work", "personal"]
+        self.options.issue_groups = [["work", "personal"]]
         self.nvim.current.buffer.lines = [
             "<!---",
             "    Date: 2018-01-01",

--- a/rplugin/python3/nvim_diary_template/tests/test_issue_helpers.py
+++ b/rplugin/python3/nvim_diary_template/tests/test_issue_helpers.py
@@ -318,14 +318,12 @@ class issue_helpersTest(unittest.TestCase):
             "",
             "##### Comment {1} - 0000-00-00 00:00: +new",
             "",
+            "",
             "### Personal",
             "",
             "#### [ ] Issue {2}: +label:personal",
             "",
             "##### Title: Test Issue 1",
-            "",
-            "##### Comment {0} - 2018-01-01 12:00:",
-            "Test comment body.",
             "",
             "##### Comment {0} - 2018-01-01 12:00:",
             "Test comment body.",
@@ -382,7 +380,7 @@ class issue_helpersTest(unittest.TestCase):
         self.nvim.current.window.cursor = (13, 0)
         insert_new_comment(self.nvim)
         assert self.nvim.current.buffer.lines == final_buffer
-        assert self.nvim.current.window.cursor == (19, 0)
+        assert self.nvim.current.window.cursor == (21, 0)
 
     def test_toggle_issue_completion(self) -> None:
         final_buffer: List[str] = [

--- a/rplugin/python3/nvim_diary_template/tests/test_make_issues.py
+++ b/rplugin/python3/nvim_diary_template/tests/test_make_issues.py
@@ -248,3 +248,108 @@ class make_issuesTest(unittest.TestCase):
         self.set_buffer()
         set_issues_from_issues_list(self.nvim, self.options, self.issues, False)
         assert self.nvim.current.buffer.lines == final_buffer
+
+    def test_set_issues_from_issues_list_with_groups(self) -> None:
+        final_buffer: List[str] = [
+            "<!---",
+            "    Date: 2018-01-01",
+            "    Tags:",
+            "--->",
+            "# Diary for 2018-01-01",
+            "",
+            "## Notes",
+            "",
+            "## Issues",
+            "",
+            "### Work",
+            "",
+            "#### [ ] Issue {3}: +label:inprogress +label:work",
+            "",
+            "##### Title: Test Issue 3",
+            "",
+            "##### Comment {0} - 2018-08-19 18:18:",
+            "Line 1",
+            "Line 2",
+            "",
+            "##### Comment {1} - 2018-08-19 12:18: +edit",
+            "Line 2-1",
+            "Line 2-2",
+            "",
+            "### Personal",
+            "",
+            "#### [ ] Issue {1}: +label:backlog +label:personal",
+            "",
+            "##### Title: Test Issue",
+            "",
+            "##### Comment {0} - 2018-08-19 18:18:",
+            "Line 1",
+            "Line 2",
+            "",
+            "#### [X] Issue {2}: +label:personal",
+            "",
+            "##### Title: Test Issue 2",
+            "",
+            "##### Comment {0} - 2018-08-19 18:18:",
+            "Line 1",
+            "Line 2",
+            "",
+            "## Schedule",
+            "",
+        ]
+
+        # Check buffer is properly set.
+        self.options.issue_groups = ["work", "personal"]
+        set_issues_from_issues_list(self.nvim, self.options, self.issues, True)
+        assert self.nvim.current.buffer.lines == final_buffer
+
+        final_buffer = [
+            "<!---",
+            "    Date: 2018-01-01",
+            "    Tags:",
+            "--->",
+            "# Diary for 2018-01-01",
+            "",
+            "## Notes",
+            "",
+            "## Issues",
+            "",
+            "### Work",
+            "",
+            "#### [ ] Issue {3}: +label:inprogress +label:work",
+            "",
+            "##### Title: Test Issue 3",
+            "",
+            "##### Comment {0} - 2018-08-19 18:18:",
+            "Line 1",
+            "Line 2",
+            "",
+            "##### Comment {1} - 2018-08-19 12:18: +edit",
+            "Line 2-1",
+            "Line 2-2",
+            "",
+            "### Personal",
+            "",
+            "#### [ ] Issue {1}: +label:backlog +label:personal",
+            "",
+            "##### Title: Test Issue",
+            "",
+            "##### Comment {0} - 2018-08-19 18:18:",
+            "Line 1",
+            "Line 2",
+            "",
+            "#### [X] Issue {2}: +label:personal",
+            "",
+            "##### Title: Test Issue 2",
+            "",
+            "##### Comment {0} - 2018-08-19 18:18:",
+            "Line 1",
+            "Line 2",
+            "",
+            "## Schedule",
+            "",
+        ]
+
+        # Check sorting works.
+        self.set_buffer()
+        set_issues_from_issues_list(self.nvim, self.options, self.issues, False)
+        assert self.nvim.current.buffer.lines == final_buffer

--- a/rplugin/python3/nvim_diary_template/tests/test_make_issues.py
+++ b/rplugin/python3/nvim_diary_template/tests/test_make_issues.py
@@ -298,7 +298,7 @@ class make_issuesTest(unittest.TestCase):
         ]
 
         # Check buffer is properly set.
-        self.options.issue_groups = ["work", "personal"]
+        self.options.issue_groups = [["work", "personal"]]
         set_issues_from_issues_list(self.nvim, self.options, self.issues, True)
         assert self.nvim.current.buffer.lines == final_buffer
 

--- a/rplugin/python3/nvim_diary_template/tests/test_make_markdown_file.py
+++ b/rplugin/python3/nvim_diary_template/tests/test_make_markdown_file.py
@@ -139,7 +139,7 @@ class make_markdown_fileTest(unittest.TestCase):
 
         nvim = MockNvim()
         nvim.current.buffer.name = "/home/crossr/diary/2018-01-01.md"
-        options.issue_groups = ["personal"]
+        options.issue_groups = [["personal"]]
         make_diary(nvim, options, gcal, github)
         final_grouped_markdown: List[str] = [
             "<!---",

--- a/rplugin/python3/nvim_diary_template/tests/test_parse_markdown.py
+++ b/rplugin/python3/nvim_diary_template/tests/test_parse_markdown.py
@@ -217,6 +217,8 @@ class parse_markdownTest(unittest.TestCase):
             " * Line 2",
             " * Line 3",
             "",
+            "### Other",
+            "",
             "#### [ ] Issue {00}: +new",
             "",
             "##### Title: New Issue 2",

--- a/rplugin/python3/nvim_diary_template/tests/test_parse_markdown.py
+++ b/rplugin/python3/nvim_diary_template/tests/test_parse_markdown.py
@@ -189,6 +189,97 @@ class parse_markdownTest(unittest.TestCase):
         result: List[GitHubIssue] = parse_markdown_file_for_issues(self.nvim)
         assert result == issues
 
+    def test_parse_markdown_file_for_grouped_issues(self) -> None:
+        self.nvim.current.buffer.lines = [
+            "<!---",
+            "    Date: 2018-01-01",
+            "    Tags:",
+            "--->",
+            "# Diary for 2018-01-01",
+            "",
+            "## Notes",
+            "",
+            "## Issues",
+            "",
+            "### Work",
+            "",
+            "#### [ ] Issue {1}: +label:work",
+            "",
+            "##### Title: Test Issue 1",
+            "",
+            "##### Comment {0} - 2018-01-01 12:00:",
+            "Test comment body.",
+            "",
+            "##### Comment {1} - 0000-00-00 00:00: +new",
+            "Test comment list:",
+            "",
+            " * Line 1",
+            " * Line 2",
+            " * Line 3",
+            "",
+            "#### [ ] Issue {00}: +new",
+            "",
+            "##### Title: New Issue 2",
+            "",
+            "##### Comment {0} - 0000-00-00 00:00: +new",
+            "New issue body.",
+            "",
+            "## Schedule",
+            "",
+            "- 10:00 - 11:00: Event 1",
+            "- 19:00 - 22:00: Event 2",
+            "- 25/01/2018 12:00 - 25/01/2018 13:00: Meeting with Alex",
+            "- 11:00 - 22:00: Event 4 {cal:Nvim Notes}",
+        ]
+
+        issues: List[GitHubIssue] = [
+            GitHubIssue(
+                number=1,
+                title="Test Issue 1",
+                complete=False,
+                labels=["work"],
+                metadata=[],
+                all_comments=[
+                    GitHubIssueComment(
+                        number=0,
+                        body=["Test comment body."],
+                        tags=[],
+                        updated_at="2018-01-01 12:00",
+                    ),
+                    GitHubIssueComment(
+                        number=1,
+                        body=[
+                            "Test comment list:",
+                            "",
+                            " * Line 1",
+                            " * Line 2",
+                            " * Line 3",
+                        ],
+                        tags=["new"],
+                        updated_at="0000-00-00 00:00",
+                    ),
+                ],
+            ),
+            GitHubIssue(
+                number=0,
+                title="New Issue 2",
+                complete=False,
+                labels=[],
+                metadata=["new"],
+                all_comments=[
+                    GitHubIssueComment(
+                        number=0,
+                        body=["New issue body."],
+                        tags=["new"],
+                        updated_at="0000-00-00 00:00",
+                    )
+                ],
+            ),
+        ]
+
+        result: List[GitHubIssue] = parse_markdown_file_for_issues(self.nvim)
+        assert result == issues
+
     def test_combine_events(self) -> None:
         markdown_events: List[CalendarEvent] = [
             CalendarEvent(name="Event 1", start="10:00", end="11:00"),

--- a/rplugin/python3/nvim_diary_template/utils/constants.py
+++ b/rplugin/python3/nvim_diary_template/utils/constants.py
@@ -67,6 +67,11 @@ PADDING_SIZE = 4
 EMPTY_TODO = "[ ]"
 BULLET_POINT = "-"
 
+# Formatting constants
+TITLE_LEVEL = 1
+CATEGORY_LEVEL = 2
+SUBGROUP_HEADING_LEVEL = 3
+
 # Options
 
 DEFAULT_SORT_ORDER = {

--- a/rplugin/python3/nvim_diary_template/utils/constants.py
+++ b/rplugin/python3/nvim_diary_template/utils/constants.py
@@ -44,6 +44,7 @@ ISSUE_COMMENT = (
 )
 ISSUE_METADATA = r"\+[a-zA-Z0-9]+"
 ISSUE_LABELS = r"\+label:[a-zA-Z0-9]+"
+SUBGROUP_HEADING = r"^### [a-zA-Z0-9]"
 
 # Event related Regex
 EVENT_REGEX = r"(?<=: ).*$"

--- a/rplugin/python3/nvim_diary_template/utils/make_issues.py
+++ b/rplugin/python3/nvim_diary_template/utils/make_issues.py
@@ -35,7 +35,7 @@ def format_issues(
     # Pre-make lists
     # This is chosen over defaultdicts since we want to ensure the insert order.
     # Also means the ordering of the option is the ordering of the issues.
-    for label in options.issue_groups:
+    for label in options.issue_groups[0]:
         full_issue_list[label] = []
     full_issue_list["other"] = []
 
@@ -44,7 +44,7 @@ def format_issues(
 
     issue: GitHubIssue
     for issue in issues:
-        common_label = list(set(issue.labels).intersection(options.issue_groups))
+        common_label = list(set(issue.labels).intersection(options.issue_groups[0]))
         if common_label != []:
             full_issue_list[common_label[0]].append(issue)
         else:

--- a/rplugin/python3/nvim_diary_template/utils/parse_markdown.py
+++ b/rplugin/python3/nvim_diary_template/utils/parse_markdown.py
@@ -33,6 +33,7 @@ from ..utils.constants import (
     ISSUE_START,
     ISSUE_TITLE,
     SCHEDULE_HEADING,
+    SUBGROUP_HEADING,
     TIME_FORMAT,
     TIME_REGEX,
     TODO_IS_CHECKED,
@@ -178,6 +179,18 @@ def parse_buffer_issues(issue_lines: List[str]) -> List[GitHubIssue]:
             ].all_comments
             current_comment: List[str] = current_issue[comment_number].body
             current_comment.append(line)
+
+        # However, we need to make sure we haven't hit a sub-group heading,
+        # so check for that as well. If it was, remove the line and also
+        # the previous line (if its whitespace).
+        # We also want to close the issue, since its finished now.
+        if (
+            re.findall(SUBGROUP_HEADING, line)
+            and issue_number != -1
+            and comment_number != -1
+        ):
+            current_comment.pop()
+            comment_number = -1
 
     # Strip any trailing new lines from the comments
     for issue in formatted_issues:


### PR DESCRIPTION
This fixes a few issues with grouped issues:

 - Stop duplicating the group headings (this was due to an issue parsing issue comments that ended up including the heading in a comment).
 - Fix comment insertion to not overflow and go past the heading.

Also adds the ability to define multiple sort styles and move between them.